### PR TITLE
fix: minor feature-dependant warnings

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,12 +18,12 @@ num-bigint = { version = "=0.4.3", default-features = false, features = ["rand"]
 
 # ZKP Generation
 ark-crypto-primitives = { version = "=0.4.0" }
-ark-ec = { version = "=0.4.1", default-features = false, features = ["parallel"] }
+ark-ec = { version = "=0.4.1", default-features = false }
 ark-ff = { version = "=0.4.1", default-features = false, features = ["parallel", "asm"] }
-ark-std = { version = "=0.4.0", default-features = false, features = ["parallel"] }
+ark-std = { version = "=0.4.0", default-features = false }
 ark-bn254 = { version = "=0.4.0" }
-ark-groth16 = { version = "=0.4.0", default-features = false, features = ["parallel"] }
-ark-poly = { version = "=0.4.1", default-features = false, features = ["parallel"] }
+ark-groth16 = { version = "=0.4.0", default-features = false }
+ark-poly = { version = "=0.4.1", default-features = false }
 ark-relations = { version = "=0.4.0", default-features = false }
 ark-serialize = { version = "=0.4.1", default-features = false }
 
@@ -52,7 +52,8 @@ name = "groth16"
 harness = false
 
 [features]
-default = ["wasmer/default", "circom-2", "ethereum"]
+default = ["parallel", "wasmer/default", "circom-2", "ethereum"]
+parallel = ["ark-ec/parallel", "ark-ff/parallel", "ark-std/parallel",  "ark-groth16/parallel", "ark-poly/parallel"]
 wasm = ["wasmer/js-default"]
 bench-complex-all = []
 circom-2 = []

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,12 +18,12 @@ num-bigint = { version = "=0.4.3", default-features = false, features = ["rand"]
 
 # ZKP Generation
 ark-crypto-primitives = { version = "=0.4.0" }
-ark-ec = { version = "=0.4.1", default-features = false }
-ark-ff = { version = "=0.4.1", default-features = false, features = ["parallel", "asm"] }
-ark-std = { version = "=0.4.0", default-features = false }
+ark-ec = { version = "=0.4.1", default-features = false, features = ["parallel"] }
+ark-ff = { version = "=0.4.1", default-features = false, features = ["asm", "parallel"] }
+ark-std = { version = "=0.4.0", default-features = false, features = ["parallel"] }
 ark-bn254 = { version = "=0.4.0" }
-ark-groth16 = { version = "=0.4.0", default-features = false }
-ark-poly = { version = "=0.4.1", default-features = false }
+ark-groth16 = { version = "=0.4.0", default-features = false, features = ["parallel"] }
+ark-poly = { version = "=0.4.1", default-features = false, features = ["parallel"] }
 ark-relations = { version = "=0.4.0", default-features = false }
 ark-serialize = { version = "=0.4.1", default-features = false }
 
@@ -51,9 +51,9 @@ ethers = "=2.0.7"
 name = "groth16"
 harness = false
 
+
 [features]
-default = ["parallel", "wasmer/default", "circom-2", "ethereum"]
-parallel = ["ark-ec/parallel", "ark-ff/parallel", "ark-std/parallel",  "ark-groth16/parallel", "ark-poly/parallel"]
+default = ["wasmer/default", "circom-2", "ethereum"]
 wasm = ["wasmer/js-default"]
 bench-complex-all = []
 circom-2 = []

--- a/src/circom/circuit.rs
+++ b/src/circom/circuit.rs
@@ -1,8 +1,8 @@
-use std::{collections::HashMap, f32::consts::E};
+use std::collections::HashMap;
 
 use ark_ff::PrimeField;
 use ark_relations::r1cs::{
-    self, ConstraintSynthesizer, ConstraintSystemRef, LinearCombination, SynthesisError, Variable,
+    ConstraintSynthesizer, ConstraintSystemRef, LinearCombination, SynthesisError, Variable,
 };
 
 use color_eyre::Result;

--- a/src/witness/circom.rs
+++ b/src/witness/circom.rs
@@ -28,6 +28,7 @@ pub trait Circom {
     fn get_ptr_raw_prime(&self) -> Result<u32>;
 }
 
+#[cfg(feature = "circom-2")]
 pub trait Circom2 {
     fn get_field_num_len32(&self) -> Result<u32>;
     fn get_raw_prime(&self) -> Result<()>;


### PR DESCRIPTION
~After reading about `rayon` fallback in non-threaded targets. See:
https://docs.rs/rayon-core/1.12.1/rayon_core/index.html#global-fallback-when-threading-is-unsupported
the decision has been to actually use `parallel` feature for all
dependencies that have it always.~

~This reduces significantly the feature management while simplifying the `Cargo.toml`.~

EDIT: After playing more with the crates. Specially after solving https://github.com/privacy-scaling-explorations/sonobe/pull/142 I realized not much stuff is needed to be done here. So this PR gets reduced to a simple fix of warnings for certain features.