### PR TITLE
feat: Support WASM module imports from in-memory binary

### DIFF
--- a/src/witness/witness_calculator.rs
+++ b/src/witness/witness_calculator.rs
@@ -64,6 +64,12 @@ impl WitnessCalculator {
         Self::from_module(module)
     }
 
+    pub fn from_binary(bytes: impl AsRef<[u8]>) -> Result<Self> {
+        let store = Store::default();
+        let module = Module::new(&store, bytes)?;
+        Self::from_module(module)
+    }
+
     pub fn from_module(module: Module) -> Result<Self> {
         let store = module.store();
 
@@ -461,7 +467,9 @@ mod tests {
     }
 
     fn run_test(case: TestCase) {
-        let mut wtns = WitnessCalculator::new(case.circuit_path).unwrap();
+        let wasm_bytes = std::fs::read(case.circuit_path).expect("Error reading the file");
+        let mut wtns = WitnessCalculator::from_binary(wasm_bytes).unwrap();
+
         assert_eq!(
             wtns.memory.prime.to_str_radix(16),
             "30644E72E131A029B85045B68181585D2833E84879B9709143E1F593F0000001".to_lowercase()


### PR DESCRIPTION
As discussed in https://github.com/arkworks-rs/circom-compat/issues/72 it's not currently possible to load parameters from their binary.

This would help a lot in browser envoiroments where JS can take care of handling the read and we just open the door in the WASM module to allow to load new ones from the bytes read.

The commit adds a change in the tests which now load from binary instead of reading from file. This ensures that the reading is indeed working as expected although we rely on a different fn from `wasmer`.

Closes #72